### PR TITLE
Step8の実装

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,7 @@ services:
     user: "trainee:mercari"
     environment:
       FRONT_URL: "http://localhost:3000"
+    # コンテナのデータを永続化(ホストOSとコンテナで共有)
+    volumes:
+      - ./go/images:/root/go/images
+      - ./db:/root/db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - api
     ports:
       - "3000:3000"
+    user: "trainee:mercari"
     # このURLをAPIエンドポイントとして使用する
     environment:
       REACT_APP_API_URL: "http://localhost:9000"
@@ -19,5 +20,6 @@ services:
       dockerfile: dockerfile
     ports:
       - "9000:9000"
+    user: "trainee:mercari"
     environment:
       FRONT_URL: "http://localhost:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.9"
+services:
+  web:
+    build:
+      # dockerfileが存在するディレクトリのパス
+      context: ./typescript/simple-mercari-web
+      # contextで指定したディレクトリ内のDockerfileの名前を指定
+      dockerfile: dockerfile
+    depends_on:
+      - app
+    ports:
+      - "3000:3000"
+    # このURLをAPIエンドポイントとして使用する
+    environment:
+      REACT_APP_API_URL: "http://localhost:9000"
+  app:
+    build:
+      context: .
+      dockerfile: dockerfile
+    ports:
+      - "9000:9000"
+    environment:
+      FRONT_URL: "http://localhost:3000"
+    volumes:
+      - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,13 +7,13 @@ services:
       # contextで指定したディレクトリ内のDockerfileの名前を指定
       dockerfile: dockerfile
     depends_on:
-      - app
+      - api
     ports:
       - "3000:3000"
     # このURLをAPIエンドポイントとして使用する
     environment:
       REACT_APP_API_URL: "http://localhost:9000"
-  app:
+  api:
     build:
       context: .
       dockerfile: dockerfile
@@ -21,5 +21,3 @@ services:
       - "9000:9000"
     environment:
       FRONT_URL: "http://localhost:3000"
-    volumes:
-      - .:/app

--- a/typescript/simple-mercari-web/dockerfile
+++ b/typescript/simple-mercari-web/dockerfile
@@ -1,7 +1,15 @@
 FROM node:20-alpine
-WORKDIR /app
 
 RUN addgroup -S mercari && adduser -S trainee -G mercari
+
+# dockerコンテナ内の作業ディレクトリ
+WORKDIR /app
+# /appの下にdockerfileが置かれているディレクトリの内容をコピー
+COPY . .
+RUN npm ci
+
+RUN chown -R trainee:mercari /app
 USER trainee
 
-CMD ["node", "-v"]
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/typescript/simple-mercari-web/src/App.css
+++ b/typescript/simple-mercari-web/src/App.css
@@ -99,8 +99,9 @@
 .grid-container {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: 20px;
-  padding: 0px 20px;
+  column-gap: 10px;
+  row-gap: 5px;
+  padding: 10px 10px;
 }
 .item-image {
   width: 200px;


### PR DESCRIPTION
## What
[STEP8: docker-composeを利用して複数のサービスを動かす](https://github.com/dongurikoko/mercari-build-training/blob/main/document/08-docker-compose.ja.md)に取り組みました。
dockerfileから build するようにしました。

## 動作確認
```
$ docker-compose up
[+] Building 0.0s (0/0)                                                                            docker:desktop-linux
[+] Running 2/0
 ✔ Container mercari-build-training-app-1  Created                                                                 0.0s 
 ✔ Container mercari-build-training-web-1  Created                                                                 0.0s 
Attaching to mercari-build-training-app-1, mercari-build-training-web-1
```
## review point

typescript/simple-mercari-web/src/App.cssの変更は、本来このPRでやるべきではなかったところなので、無視していただけると幸いです。
